### PR TITLE
Fix enums - they start with zero by default

### DIFF
--- a/RFGravatarImageView/RFGravatarImageView.h
+++ b/RFGravatarImageView/RFGravatarImageView.h
@@ -12,6 +12,7 @@
 // Rating of Gravatar
 
 enum {
+    GravatarRatingAny,
     GravatarRatingG,
     GravatarRatingPG,
     GravatarRatingR,
@@ -22,6 +23,7 @@ typedef NSUInteger GravatarRatings;
 // Default Gravatar types: http://bit.ly/1cCmtdb
 
 enum {
+    DefaultGravatarNone,
     DefaultGravatar404,
     DefaultGravatarMysteryMan,
     DefaultGravatarIdenticon,


### PR DESCRIPTION
DefaultGravatar404 was 0 by default and it was not working. Now its value is 1, and it passes 'if (_defaultGravatar)' test.
