### PR TITLE
Set proper placeholder when loading image using sdwebimage

### DIFF
--- a/RFGravatarImageView/RFGravatarImageView.m
+++ b/RFGravatarImageView/RFGravatarImageView.m
@@ -53,8 +53,15 @@
 }
 
 - (void)load {
-    [self sd_setImageWithURL:[self gravatarURL:_email] completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
-    }];
+    if (self.placeholder) {
+        [self sd_setImageWithURL:[self gravatarURL:_email] placeholderImage:self.placeholder completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
+            
+        }];
+    } else {
+        [self sd_setImageWithURL:[self gravatarURL:_email] completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
+        }];
+    }
+
 }
 
 - (void)loadGravatar:(void (^)(void))success {


### PR DESCRIPTION
The placeholder image will become white at the moment of loading image from gravatar even though the placeholder image has been set before load. Placeholder image has to be properly set on sdwebimage, not by manually assigning image to it.

This will become noticeable on bad internet connection