### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ RFGravatarImageView<br /> [![RFGravatarImageView Version](http://img.shields.io/
 
 A simple UIImageView subclass for dealing with http://gravatar.com images.
 
-##Installation
+## Installation
 
 ### Installation with CocoaPods
 
@@ -44,6 +44,6 @@ See [RFGravatarImageView.h](RFGravatarImageView/RFGravatarImageView.h) to view e
 
 Hope you enjoy it!  Please Fork and send Pull Requests!
 
-##License
+## License
 
 RFGravatarImageView is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
